### PR TITLE
Fix missing chat path mapping

### DIFF
--- a/src/main/java/com/jobrecruitment/controller/common/MessagingController.java
+++ b/src/main/java/com/jobrecruitment/controller/common/MessagingController.java
@@ -56,6 +56,11 @@ public class MessagingController {
         return "redirect:/messages?userId=" + receiverId;
     }
 
+    @GetMapping({"/application", "/application/"})
+    public String applicationRootRedirect() {
+        return "redirect:/";
+    }
+
     @GetMapping("/application/{applicationId}")
     public String applicationChat(@PathVariable Long applicationId, HttpSession session, Model model) {
         User user = (User) session.getAttribute("loggedUser");


### PR DESCRIPTION
## Summary
- handle `/messages/application` requests without an ID

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68571f5952e0832db0a870c7309b310c