### PR TITLE
Fix chat links without application id

### DIFF
--- a/src/main/java/com/jobrecruitment/config/GlobalModelAttributeAdvice.java
+++ b/src/main/java/com/jobrecruitment/config/GlobalModelAttributeAdvice.java
@@ -35,7 +35,8 @@ public class GlobalModelAttributeAdvice {
     public List<Message> globalMessages(HttpSession session) {
         User user = (User) session.getAttribute("loggedUser");
         if (user == null) return Collections.emptyList();
-        return messageRepository.findTop5ByReceiverIdOrderBySentAtDesc(user.getId());
+        return messageRepository
+                .findTop5ByReceiverIdAndApplicationIsNotNullOrderBySentAtDesc(user.getId());
     }
 
 }

--- a/src/main/java/com/jobrecruitment/repository/common/MessageRepository.java
+++ b/src/main/java/com/jobrecruitment/repository/common/MessageRepository.java
@@ -11,5 +11,5 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
     List<Message> findByReceiverIdAndIsReadFalse(Long receiverId);
     List<Message> findByApplicationIdOrderBySentAt(Long applicationId);
     Optional<Message> findFirstBySenderIdOrReceiverIdOrderBySentAtDesc(Long senderId, Long receiverId);
-    List<Message> findTop5ByReceiverIdOrderBySentAtDesc(Long receiverId);
+    List<Message> findTop5ByReceiverIdAndApplicationIsNotNullOrderBySentAtDesc(Long receiverId);
 }


### PR DESCRIPTION
## Summary
- refine message repository query to ignore messages without an application
- update global model advice to use the refined query

## Testing
- `./mvnw -q test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6857210d395c832da15b3fb1846004a4