### PR TITLE
Fix chat button to open modal

### DIFF
--- a/src/main/webapp/WEB-INF/views/common/index.jsp
+++ b/src/main/webapp/WEB-INF/views/common/index.jsp
@@ -153,7 +153,8 @@
                                     <c:choose>
                                         <c:when test="${approvedMap[job.id]}">
                                             <span class="btn btn-sm btn-success disabled">Approved</span>
-                                            <a href="${pageContext.request.contextPath}/messages/application/${applicationIdMap[job.id]}" class="btn btn-sm btn-primary">Chat</a>
+                                            <a href="#" class="btn btn-sm btn-primary chat-link"
+                                               data-chat-url="${pageContext.request.contextPath}/messages/application/${applicationIdMap[job.id]}">Chat</a>
                                         </c:when>
                                         <c:when test="${appliedMap[job.id]}">
                                             <span class="btn btn-sm btn-secondary disabled">Already Applied</span>

--- a/src/main/webapp/WEB-INF/views/common/job-detail.jsp
+++ b/src/main/webapp/WEB-INF/views/common/job-detail.jsp
@@ -48,8 +48,8 @@
                         <span class="btn btn-secondary disabled">Already Applied</span>
 
                         <c:if test="${not empty applicationId}">
-                            <a href="${pageContext.request.contextPath}/messages/application/${applicationId}"
-                               class="btn btn-outline-primary ms-2">
+                            <a href="#" class="btn btn-outline-primary ms-2 chat-link"
+                               data-chat-url="${pageContext.request.contextPath}/messages/application/${applicationId}">
                                 💬 Message Recruiter
                             </a>
                         </c:if>


### PR DESCRIPTION
## Summary
- use chat modal when clicking Chat on home page job card
- make the Chat link on job detail page open the same modal

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685723aaeaf4832d8c946e6bf10d1e0e