### PR TITLE
Update job detail apply button logic

### DIFF
--- a/src/main/java/com/jobrecruitment/controller/common/JobDetailController.java
+++ b/src/main/java/com/jobrecruitment/controller/common/JobDetailController.java
@@ -1,7 +1,10 @@
 package com.jobrecruitment.controller.common;
 
+import com.jobrecruitment.model.User;
+import com.jobrecruitment.model.applicant.Application;
 import com.jobrecruitment.model.recruiter.JobPosting;
 import com.jobrecruitment.model.recruiter.JobSkill;
+import com.jobrecruitment.repository.applicant.ApplicationRepository;
 import com.jobrecruitment.repository.recruiter.JobPostingRepository;
 import com.jobrecruitment.repository.recruiter.JobSkillRepository;
 import jakarta.servlet.http.HttpSession;
@@ -13,6 +16,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 
 @Controller
 @RequiredArgsConstructor
@@ -20,6 +25,7 @@ public class JobDetailController {
 
     private final JobPostingRepository jobPostingRepository;
     private final JobSkillRepository jobSkillRepository;
+    private final ApplicationRepository applicationRepository;
 
     @GetMapping("/job/{id}")
     public String jobDetail(@PathVariable("id") Integer id,
@@ -36,6 +42,19 @@ public class JobDetailController {
         List<JobSkill> skills = jobSkillRepository.findByJobPostingId(id);
         model.addAttribute("job", job);
         model.addAttribute("skills", skills);
+
+        User user = (User) session.getAttribute("loggedUser");
+        if (user != null && user.getRole().name().equals("APPLICANT")) {
+            Application application = applicationRepository
+                    .findByApplicantIdAndJobId(user.getId(), job.getId().longValue());
+            if (application != null) {
+                Map<Integer, Boolean> appliedMap = new HashMap<>();
+                appliedMap.put(job.getId(), true);
+                model.addAttribute("appliedMap", appliedMap);
+                model.addAttribute("applicationId", application.getId());
+            }
+        }
+
         return "common/job-detail";
     }
 }


### PR DESCRIPTION
## Summary
- detect previous applications in `JobDetailController`
- expose `appliedMap` and `applicationId` so the job detail page shows *Already Applied* when appropriate

## Testing
- `./mvnw -q test` *(fails: Failed to fetch apache-maven)*

------
https://chatgpt.com/codex/tasks/task_e_68572d3448a8832db75a7778519ce04e